### PR TITLE
resolve #503

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -301,7 +301,7 @@ var Game = {
 
         for (var i = 0; i < stage * 3; i++) {
             var alien = aliens.create(Math.random() * 290, Math.random() * 540, 'invader');
-            while(game.physics.arcade.overlap(alien, aliens)){
+            while(game.physics.arcade.overlap(alien, aliens) || game.physics.arcade.overlap(alien, player)){
                 alien.kill();
                 alien = aliens.create(Math.random() * 290, Math.random() * 540, 'invader');
             }


### PR DESCRIPTION
스테이지가 바뀌고 새로 적 기체를 생성할 때 생성 위치가 x = 0\~290, y = 0\~540에 먼저 생성된 후에 그룹의 포지션으로 이동되는데, 플레이어와 충돌되는 위치에 생성된다면 그룹 포지션으로 이동되기 전 먼저 충돌체크가 진행되어 플레이어 기체가 피격되는 것으로 보입니다.

적 기체 생성시 플레이어와 충돌이 일어나는 위치라면 다시 위치를 랜덤으로 생성되게 하여 해결하였습니다.